### PR TITLE
Restructure all vision code

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TFTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TFTest.java
@@ -29,11 +29,10 @@
 
 package org.firstinspires.ftc.teamcode;
 
-import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
-import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.qualcomm.robotcore.util.ElapsedTime;
+
+import org.firstinspires.ftc.teamcode.vision.TensorflowIntegration;
 
 /**
  * Demonstrates empty OpMode

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/GoldPos.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/GoldPos.java
@@ -1,0 +1,5 @@
+package org.firstinspires.ftc.teamcode.vision;
+
+public enum GoldPos {
+    LEFT, MIDDLE, RIGHT, ERROR1, ERROR2, ERROR3, HOLD_STATE;
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/OpenCVIntegration.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/OpenCVIntegration.java
@@ -1,0 +1,20 @@
+package org.firstinspires.ftc.teamcode.vision;
+
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+
+public class OpenCVIntegration implements VisionProvider {
+
+    public void initializeVision(HardwareMap hardwareMap, Telemetry telemetry) {
+
+    }
+
+    public void shutdownVision() {
+
+    }
+
+    public GoldPos detect() {
+        return GoldPos.ERROR3;
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/TensorflowIntegration.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/TensorflowIntegration.java
@@ -26,10 +26,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.firstinspires.ftc.teamcode;
+package org.firstinspires.ftc.teamcode.vision;
 
-import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
-import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
 import org.firstinspires.ftc.robotcore.external.ClassFactory;
@@ -38,10 +36,11 @@ import org.firstinspires.ftc.robotcore.external.navigation.VuforiaLocalizer;
 import org.firstinspires.ftc.robotcore.external.navigation.VuforiaLocalizer.CameraDirection;
 import org.firstinspires.ftc.robotcore.external.tfod.Recognition;
 import org.firstinspires.ftc.robotcore.external.tfod.TFObjectDetector;
+import org.firstinspires.ftc.teamcode.RC;
 
 import java.util.List;
 
-public class TensorflowIntegration {
+public class TensorflowIntegration implements VisionProvider {
     private static final String TFOD_MODEL_ASSET = "RoverRuckus.tflite";
     private static final String LABEL_GOLD_MINERAL = "Gold Mineral";
     private static final String LABEL_SILVER_MINERAL = "Silver Mineral";
@@ -96,7 +95,8 @@ public class TensorflowIntegration {
         tfod.loadModelFromAsset(TFOD_MODEL_ASSET, LABEL_GOLD_MINERAL, LABEL_SILVER_MINERAL);
     }
 
-    public void tfInit(HardwareMap hardwareMap, Telemetry telemetry) {
+    @Override
+    public void initializeVision(HardwareMap hardwareMap, Telemetry telemetry) {
         initVuforia();
 
         if (ClassFactory.getInstance().canCreateTFObjectDetector()) {
@@ -110,12 +110,14 @@ public class TensorflowIntegration {
         }
     }
 
-    public void tfDisable() {
+    @Override
+    public void shutdownVision() {
         if (tfod != null) {
             tfod.shutdown();
         }
     }
 
+    @Override
     public GoldPos detect() {
         List<Recognition> updatedRecognitions = tfod.getUpdatedRecognitions();
         if (updatedRecognitions != null) {
@@ -145,10 +147,6 @@ public class TensorflowIntegration {
         }
         return GoldPos.ERROR1;
 
-    }
-
-    public enum GoldPos {
-        LEFT, MIDDLE, RIGHT, ERROR1;
     }
 
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/VisionProvider.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/vision/VisionProvider.java
@@ -1,0 +1,15 @@
+package org.firstinspires.ftc.teamcode.vision;
+
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+
+public interface VisionProvider {
+
+    public void initializeVision(HardwareMap hardwareMap, Telemetry telemetry);
+
+    public void shutdownVision();
+
+    public GoldPos detect();
+
+}


### PR DESCRIPTION
Moved vision code to its own package
Aded VisionProvider interface
Refactored TFIntegration to implement VisionProvider
Added dummy OpenCVIntegration class implelemts VisionProvider
Changed Game_6832 to be able to select VisionProvider backends on the fly
Added support for VisionBackends taking multiple opmode loops to finish detection
  without hogging up too much of the CPU
Moved GoldPos to its own class

Before issuing a pull request, please see the contributing page.
