### PR TITLE
Cleaned up articulation code a lot

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Collector.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Collector.java
@@ -69,6 +69,10 @@ public class Collector {
     public static int extendMin = 300;  //prevent crunching collector tray
     public static int extendPreLatch = extendMax;
 
+    //trueArticulation tolerances
+    public static int extendABobTolerance = 15;
+    public static int elbowTolerance = 15;
+
     //filler value; needs to be updated to reflect actual ratio
     public double ticksPerDegree = 5;
 
@@ -171,8 +175,11 @@ public class Collector {
     public int getElbowCurrentPos(){
         return elbowLeft.getCurrentPosition();
     }
-    public int getElbowCurrentPos2(){
+    public int getElbowCurrentPos2() {
         return elbowRight.getCurrentPosition();
+    }
+    public int getElbowCurrentPosAvg() {
+        return (getElbowCurrentPos() + getElbowCurrentPos2())/2;
     }
     public void setElbowPwr(double pwr){ elbowPwr = pwr; }
 
@@ -245,11 +252,11 @@ public class Collector {
     }
 
     public boolean nearTargetExtend(){
-        if((Math.abs(getExtendABobCurrentPos()-getExtendABobTargetPos()))<15) return true;
+        if((Math.abs(getExtendABobCurrentPos()-getExtendABobTargetPos()))<extendABobTolerance) return true;
         else return false;
     }
     public boolean nearTargetElbow(){
-        if ((Math.abs( getElbowCurrentPos()-getElbowTargetPos()))<15) return true;
+        if ((Math.abs( getElbowCurrentPos()-getElbowTargetPos()))<elbowTolerance) return true;
         else return false;
     }
     public boolean nearTarget(){


### PR DESCRIPTION
UNTESTED CODE!!

I made major changes to how articulations work, so expect bugs.
There are also lots of places I could have made typos as well during conversion.

This commit completely reworks the articulation framework.
Articulations are now split into `trueArticulation` - which represents the physical state of the robot,
and `desiredArticulation` - which represents the desired state of the robot.

`trueArticulation` is going to be `inprogress` for most of the transition. `desiredArticulation` tells you where the robot wants to go.

Set `desiredArticulation = Articulation.manual` to stop the sequence.